### PR TITLE
do proper add/delete expectation handling

### DIFF
--- a/pkg/virt-operator/application.go
+++ b/pkg/virt-operator/application.go
@@ -69,7 +69,7 @@ type VirtOperatorApp struct {
 	kubeVirtCache    cache.Store
 
 	stores    util.Stores
-	informers []cache.SharedIndexInformer
+	informers util.Informers
 }
 
 var _ service.Service = &VirtOperatorApp{}
@@ -99,32 +99,29 @@ func Execute() {
 	app.kubeVirtInformer = app.informerFactory.KubeVirt()
 	app.kubeVirtCache = app.kubeVirtInformer.GetStore()
 
-	app.informers = append(app.informers, app.informerFactory.OperatorServiceAccount())
-	app.stores.ServiceAccountCache = app.informers[len(app.informers)-1].GetStore()
+	app.informers = util.Informers{
+		ServiceAccount:     app.informerFactory.OperatorServiceAccount(),
+		ClusterRole:        app.informerFactory.OperatorClusterRole(),
+		ClusterRoleBinding: app.informerFactory.OperatorClusterRoleBinding(),
+		Role:               app.informerFactory.OperatorRole(),
+		RoleBinding:        app.informerFactory.OperatorRoleBinding(),
+		Crd:                app.informerFactory.OperatorCRD(),
+		Service:            app.informerFactory.OperatorService(),
+		Deployment:         app.informerFactory.OperatorDeployment(),
+		DaemonSet:          app.informerFactory.OperatorDaemonSet(),
+	}
 
-	app.informers = append(app.informers, app.informerFactory.OperatorClusterRole())
-	app.stores.ClusterRoleCache = app.informers[len(app.informers)-1].GetStore()
-
-	app.informers = append(app.informers, app.informerFactory.OperatorClusterRoleBinding())
-	app.stores.ClusterRoleBindingCache = app.informers[len(app.informers)-1].GetStore()
-
-	app.informers = append(app.informers, app.informerFactory.OperatorRole())
-	app.stores.RoleCache = app.informers[len(app.informers)-1].GetStore()
-
-	app.informers = append(app.informers, app.informerFactory.OperatorRoleBinding())
-	app.stores.RoleBindingCache = app.informers[len(app.informers)-1].GetStore()
-
-	app.informers = append(app.informers, app.informerFactory.OperatorCRD())
-	app.stores.CrdCache = app.informers[len(app.informers)-1].GetStore()
-
-	app.informers = append(app.informers, app.informerFactory.OperatorService())
-	app.stores.ServiceCache = app.informers[len(app.informers)-1].GetStore()
-
-	app.informers = append(app.informers, app.informerFactory.OperatorDeployment())
-	app.stores.DeploymentCache = app.informers[len(app.informers)-1].GetStore()
-
-	app.informers = append(app.informers, app.informerFactory.OperatorDaemonSet())
-	app.stores.DaemonSetCache = app.informers[len(app.informers)-1].GetStore()
+	app.stores = util.Stores{
+		ServiceAccountCache:     app.informerFactory.OperatorServiceAccount().GetStore(),
+		ClusterRoleCache:        app.informerFactory.OperatorClusterRole().GetStore(),
+		ClusterRoleBindingCache: app.informerFactory.OperatorClusterRoleBinding().GetStore(),
+		RoleCache:               app.informerFactory.OperatorRole().GetStore(),
+		RoleBindingCache:        app.informerFactory.OperatorRoleBinding().GetStore(),
+		CrdCache:                app.informerFactory.OperatorCRD().GetStore(),
+		ServiceCache:            app.informerFactory.OperatorService().GetStore(),
+		DeploymentCache:         app.informerFactory.OperatorDeployment().GetStore(),
+		DaemonSetCache:          app.informerFactory.OperatorDaemonSet().GetStore(),
+	}
 
 	app.kubeVirtRecorder = app.getNewRecorder(k8sv1.NamespaceAll, "virt-operator")
 	app.kubeVirtController = *NewKubeVirtController(app.clientSet, app.kubeVirtInformer, app.kubeVirtRecorder, app.stores, app.informers)

--- a/pkg/virt-operator/creation/all.go
+++ b/pkg/virt-operator/creation/all.go
@@ -28,25 +28,24 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-operator/util"
 )
 
-func Create(kv *v1.KubeVirt, config util.KubeVirtDeploymentConfig, stores util.Stores, clientset kubecli.KubevirtClient) (int, error) {
+func Create(kv *v1.KubeVirt, config util.KubeVirtDeploymentConfig, stores util.Stores, clientset kubecli.KubevirtClient, expectations *util.Expectations) (int, error) {
 
 	objectsAdded := 0
 
-	added, err := rbac.CreateClusterRBAC(clientset, kv, stores)
+	added, err := rbac.CreateClusterRBAC(clientset, kv, stores, expectations)
 	objectsAdded = objectsAdded + added
 	if err != nil {
 		log.Log.Errorf("Failed to create cluster RBAC: %v", err)
 		return objectsAdded, err
 	}
-
-	added, err = rbac.CreateApiServerRBAC(clientset, kv, stores)
+	added, err = rbac.CreateApiServerRBAC(clientset, kv, stores, expectations)
 	objectsAdded = objectsAdded + added
 	if err != nil {
 		log.Log.Errorf("Failed to create apiserver RBAC: %v", err)
 		return objectsAdded, err
 	}
 
-	added, err = rbac.CreateControllerRBAC(clientset, kv, stores)
+	added, err = rbac.CreateControllerRBAC(clientset, kv, stores, expectations)
 	objectsAdded = objectsAdded + added
 	if err != nil {
 		log.Log.Errorf("Failed to create controller RBAC: %v", err)
@@ -59,14 +58,14 @@ func Create(kv *v1.KubeVirt, config util.KubeVirtDeploymentConfig, stores util.S
 		return objectsAdded, err
 	}
 
-	added, err = components.CreateCRDs(clientset, stores)
+	added, err = components.CreateCRDs(clientset, kv, stores, expectations)
 	objectsAdded = objectsAdded + added
 	if err != nil {
 		log.Log.Errorf("Failed to create crds: %v", err)
 		return objectsAdded, err
 	}
 
-	added, err = components.CreateControllers(clientset, kv, config, stores)
+	added, err = components.CreateControllers(clientset, kv, config, stores, expectations)
 	objectsAdded = objectsAdded + added
 	if err != nil {
 		log.Log.Errorf("Failed to create controllers: %v", err)

--- a/pkg/virt-operator/creation/rbac/controller.go
+++ b/pkg/virt-operator/creation/rbac/controller.go
@@ -21,6 +21,7 @@ package rbac
 import (
 	"fmt"
 
+	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/log"
 	"kubevirt.io/kubevirt/pkg/virt-operator/util"
 
@@ -33,15 +34,21 @@ import (
 	"kubevirt.io/kubevirt/pkg/kubecli"
 )
 
-func CreateControllerRBAC(clientset kubecli.KubevirtClient, kv *virtv1.KubeVirt, stores util.Stores) (int, error) {
+func CreateControllerRBAC(clientset kubecli.KubevirtClient, kv *virtv1.KubeVirt, stores util.Stores, expectations *util.Expectations) (int, error) {
 
 	objectsAdded := 0
 	core := clientset.CoreV1()
+	kvkey, err := controller.KeyFunc(kv)
+	if err != nil {
+		return 0, err
+	}
 
 	sa := newControllerServiceAccount(kv.Namespace)
 	if _, exists, _ := stores.ServiceAccountCache.Get(sa); !exists {
+		expectations.ServiceAccount.RaiseExpectations(kvkey, 1, 0)
 		_, err := core.ServiceAccounts(kv.Namespace).Create(sa)
 		if err != nil && !apierrors.IsAlreadyExists(err) {
+			expectations.ServiceAccount.LowerExpectations(kvkey, 1, 0)
 			return objectsAdded, fmt.Errorf("unable to create serviceaccount %+v: %v", sa, err)
 		} else if err == nil {
 			objectsAdded++
@@ -54,8 +61,10 @@ func CreateControllerRBAC(clientset kubecli.KubevirtClient, kv *virtv1.KubeVirt,
 
 	cr := newControllerClusterRole()
 	if _, exists, _ := stores.ClusterRoleCache.Get(cr); !exists {
+		expectations.ClusterRole.RaiseExpectations(kvkey, 1, 0)
 		_, err := rbac.ClusterRoles().Create(cr)
 		if err != nil && !apierrors.IsAlreadyExists(err) {
+			expectations.ClusterRole.LowerExpectations(kvkey, 1, 0)
 			return objectsAdded, fmt.Errorf("unable to create clusterrole %+v: %v", cr, err)
 		} else if err == nil {
 			objectsAdded++
@@ -66,8 +75,10 @@ func CreateControllerRBAC(clientset kubecli.KubevirtClient, kv *virtv1.KubeVirt,
 
 	crb := newControllerClusterRoleBinding(kv.Namespace)
 	if _, exists, _ := stores.ClusterRoleBindingCache.Get(crb); !exists {
+		expectations.ClusterRoleBinding.RaiseExpectations(kvkey, 1, 0)
 		_, err := rbac.ClusterRoleBindings().Create(crb)
 		if err != nil && !apierrors.IsAlreadyExists(err) {
+			expectations.ClusterRoleBinding.LowerExpectations(kvkey, 1, 0)
 			return objectsAdded, fmt.Errorf("unable to create clusterrolebinding %+v: %v", crb, err)
 		} else if err == nil {
 			objectsAdded++

--- a/pkg/virt-operator/util/types.go
+++ b/pkg/virt-operator/util/types.go
@@ -18,7 +18,11 @@
  */
 package util
 
-import "k8s.io/client-go/tools/cache"
+import (
+	"k8s.io/client-go/tools/cache"
+
+	"kubevirt.io/kubevirt/pkg/controller"
+)
 
 type Stores struct {
 	ServiceAccountCache     cache.Store
@@ -30,4 +34,64 @@ type Stores struct {
 	ServiceCache            cache.Store
 	DeploymentCache         cache.Store
 	DaemonSetCache          cache.Store
+}
+
+type Expectations struct {
+	ServiceAccount     *controller.UIDTrackingControllerExpectations
+	ClusterRole        *controller.UIDTrackingControllerExpectations
+	ClusterRoleBinding *controller.UIDTrackingControllerExpectations
+	Role               *controller.UIDTrackingControllerExpectations
+	RoleBinding        *controller.UIDTrackingControllerExpectations
+	Crd                *controller.UIDTrackingControllerExpectations
+	Service            *controller.UIDTrackingControllerExpectations
+	Deployment         *controller.UIDTrackingControllerExpectations
+	DaemonSet          *controller.UIDTrackingControllerExpectations
+}
+
+type Informers struct {
+	ServiceAccount     cache.SharedIndexInformer
+	ClusterRole        cache.SharedIndexInformer
+	ClusterRoleBinding cache.SharedIndexInformer
+	Role               cache.SharedIndexInformer
+	RoleBinding        cache.SharedIndexInformer
+	Crd                cache.SharedIndexInformer
+	Service            cache.SharedIndexInformer
+	Deployment         cache.SharedIndexInformer
+	DaemonSet          cache.SharedIndexInformer
+}
+
+func (e *Expectations) DeleteExpectations(key string) {
+	e.ServiceAccount.DeleteExpectations(key)
+	e.ClusterRole.DeleteExpectations(key)
+	e.ClusterRoleBinding.DeleteExpectations(key)
+	e.Role.DeleteExpectations(key)
+	e.RoleBinding.DeleteExpectations(key)
+	e.Crd.DeleteExpectations(key)
+	e.Service.DeleteExpectations(key)
+	e.Deployment.DeleteExpectations(key)
+	e.DaemonSet.DeleteExpectations(key)
+}
+
+func (e *Expectations) ResetExpectations(key string) {
+	e.ServiceAccount.SetExpectations(key, 0, 0)
+	e.ClusterRole.SetExpectations(key, 0, 0)
+	e.ClusterRoleBinding.SetExpectations(key, 0, 0)
+	e.Role.SetExpectations(key, 0, 0)
+	e.RoleBinding.SetExpectations(key, 0, 0)
+	e.Crd.SetExpectations(key, 0, 0)
+	e.Service.SetExpectations(key, 0, 0)
+	e.Deployment.SetExpectations(key, 0, 0)
+	e.DaemonSet.SetExpectations(key, 0, 0)
+}
+
+func (e *Expectations) SatisfiedExpectations(key string) bool {
+	return e.ServiceAccount.SatisfiedExpectations(key) ||
+		e.ClusterRole.SatisfiedExpectations(key) ||
+		e.ClusterRoleBinding.SatisfiedExpectations(key) ||
+		e.Role.SatisfiedExpectations(key) ||
+		e.RoleBinding.SatisfiedExpectations(key) ||
+		e.Crd.SatisfiedExpectations(key) ||
+		e.Service.SatisfiedExpectations(key) ||
+		e.Deployment.SatisfiedExpectations(key) ||
+		e.DaemonSet.SatisfiedExpectations(key)
 }


### PR DESCRIPTION
Untested except from compile, but this now does proper add/delete expectation watching.

The main problem before was that objects marked for deletion were not counted as delete observation.